### PR TITLE
用了一个新办法来build CUDA driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 .vagrant
 cuda
+linux
+.config

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*~
+.vagrant
+coreos-vagrant
+cuda
+Vagrantfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 *~
 .vagrant
-coreos-vagrant
 cuda
-Vagrantfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:14.04
+MAINTAINER Yi Wang <yi.wang.2005@gmail.com>
+
+COPY build.sh /opt
+
+CMD /opt/build.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM ubuntu:14.04
-MAINTAINER Yi Wang <yi.wang.2005@gmail.com>
-
-COPY build.sh /opt
-
-CMD /opt/build.sh
-

--- a/README.md
+++ b/README.md
@@ -8,152 +8,62 @@ described [here](https://github.com/wangkuiyi/k8s-ml), which makes use
 of Kubernetes to run jobs in Docker containers.  An ideal platform to
 run Kubernetes is CoreOS.  However, CoreOS doesn't include CUDA GPU
 driver in its kernel.  In order to use GPUs for accelerated deep
-learning, we build CUDA GPU driver as kernel modules, and load them in
-Docker images of Tensorflow, Torch and other programs that relies on
-CUDA GPU drivers.  At runtime, we load CUDA driver kernel modules from
-within Docker containers.
+learning, we want to build CUDA GPU driver as kernel modules and to
+load them in Docker images together with Tensorflow, Torch and other
+programs that relies on CUDA GPU drivers.  At runtime, we load CUDA
+driver kernel modules from within Docker containers.
 
 ## Solution
 
-Thanks https://github.com/emergingstack/es-dev-stack, which shows that
+https://github.com/emergingstack/es-dev-stack shows that
 above idea works.  The problem with the `es-dev-stack` tool is that
 the provided Dockerfile builds too big CUDA Docker images.  Actually,
 the disk space of an AWS EC2 g2.8xlarge instance doesn't support build
-and run such images.  Our solution is a two-phase approach:
+and run such images.
 
-1. The `builder` image downloads necessary Linux kernel and CUDA Toolkit
-   and build CUDA drivers as kernel modules.  `builder` can run on a
-   VirtualBox VM with enough big disk spaces.  The host of the VM
-   doesn't need to have CUDA GPU.  `builder` is derived from
-   `ubuntu:14.04` image.  `builder` writes two kernel modules files:
+So I use a two-phase approach: build a Docker image which build CUDA
+kernel drivers at runtime, and build application images that loads
+CUDA drivers and GPU applications.  This repo focuses on the first
+phase.
 
- 1. `nvidia.ko`
- 1. `nvidia-uvm.ko`
+## Build
 
-1. Some `cuda` images, each based on Tensorflow image or Torch image,
-   as well as the two kernel modules.  The Dockerfile runs command
-   like `insmod /opt/nvidia.ko && insmod /opt/nvidia-uvm.so` to load
-   kernel modules before starting programs that rely on GPU.  These
-   `cuda` images are supposed to run on computers with Docker and GPU.
+The primary challenge is that the building process needs CUDA Toolkit
+and Linux kernel source code, both take huge amount of disk space.  My
+solution is to use the disk space of the host computer (my iMac 5K) as
+much as possible.
 
+My iMac doesn't run CoreOS, so I need to run a virtual machine with
+CoreOS.  A practical and convenient way to this is to use the standard
+Vagrant CoreOS box.  Here is what I do:
 
-## The `Builder` Image
+1. Run `git clone` to get this repo on the host computer.
+1. Run `run.sh`, which
+  1. downloads and unpacks CUDA Toolkit into `./cuda` (on host),
+  1. executes `vagrant box update` to retrieve the most recent version of CoreOS alpha channel box,
+  1. executes `vagrant up` to bring the CoreOS VM up and mounts the current host directory to VM's `/home/core/share`,
+  1. executes `vagrant ssh -c "docker build -t cuda /home/core/share"` to build the CUDA builder Docker image on VM,
+  1. executes `vagrant ssh -c "docker run -v /home/core/share:/opt/share cuda"` to run the CUDA builder image and builds CUDA modules.
 
-I followed
-[this tutorial](https://gist.github.com/noonat/9fc170ea0c6ddea69c58)
-and successfully installed CoreOS into disks of a VirtualBox VM.  The
-general idea is that I boot the VM using a CoreOS ISO image, and run a
-script `coreos-install` in that image to install CoreOS into the
-specified disk, say `/dev/sda`.  The script requires a config file,
-which should contain at least a user's SSH public key, so that the
-user can ssh to the CoreOS VM later.  I put this config file into my
-Github repo, and CoreOS has basic network tools like curl, which can
-be used to download the config file for use by `coreos-install`.
+Note that the current directory `./` of the host is mount to the VM at
+`/home/core/share`.  As specified in Vagrantfile, this mount is via
+NFS, so that any changes of `./` of the host of `/home/core/share` on
+the VM is transparent to each other.
 
-I tried to follow https://github.com/emergingstack/es-dev-stack/ to
-build a Docker image of CUDA kernel module.  It builds.  But when I
-run the built docker image, it complains that the system doesn't have
-CUDA GPU. (Yes, it is a VM that doesn't have any GPU).
+`/home/core/share` on the VM is then mapped to `/opt/share` when we
+run the builder Docker container.
 
-## CoreOS on AWS EC2
+The builder Docker container checks out the version of Linux kernel
+source code that matches the CoreOS kernel running in the VM.  If you
+want to use another channels of CoreOS, say stable or beta, please
+edit Vagrantfile to use the according Vagrant box.
 
-It is true that we can create CoreOS instances as explained in
-[this post](http://tleyden.github.io/blog/2014/11/04/coreos-with-nvidia-cuda-gpu-drivers/),
-but I cannot find a way to ssh to the instance.  So I resorted to
-CloudFoundation to create a CoreOS cluster with at least 3 instances.
-CoreOS's tutorial lacks details, reasons, explanations.  Luckily, I
-found [this tutorial](https://deis.com/blog/2016/coreos-on-aws/).
+The checked out Linux kernel source code is put in `/opt/share/linux`.
+You will notice `./linux` on the host.
 
-### Too Big Docker Image to Build
+## Pitfalls
 
-It is notable that the Dockerfile will run out of disk space on either
-`g2.x2large` nodes or `g2.8xlarge` nodes.  So I tried to git clone
-only the most recent commit of the wanted branch of Linux kernel code:
-
-1. `git clone git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux` gives 1.8GB.
-1. Then I removed the `.git` subdirectory. It leaves 715MB.
-1. `git clone -b v4.4.8 --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux` gives 850MB
-1. Then I removed the `.git` subdirectory. It leaves 696MB.
-
-Anyway, I cannot build the Docker image on even `g2.8xlarge`.
-
-So I go back to use VirtualBox VM and installed CoreOS 899.15.0.
-After ssh into the VM, `uname -r` shows Linux kernel version 4.3.6 --
-exactly as that on AWS!
-
-So I build the Docker image on the VM, tag and push it:
-
-```
-docker tag xxxxxx cxwangyi/cuda:v1
-docker login --username=cxwangyi --email=yi.wang.2005@gmail.com
-docker push cxwangyi/cuda
-```
-
-Then on an EC2 CUDA instance, I run:
-
-```
-docker run -it --priviledged cxwangyi/cuda:v1
-```
-
-### Too Big Docker Image to Pull
-
-However, this complains that the Docker image to be pulled is too big
-and runs out of disk space.  The question becomes: how to make Docker
-images smaller.  Google told me --
-[docker-squash](https://github.com/jwilder/docker-squash).
-
-I downloaded pre-built docker-squash from its Github README.md page,
-and scp to my VirtualBox VM, untar there.  Then I followed the
-[usage description](http://jasonwilder.com/blog/2014/08/19/squashing-docker-images/)
-to remove Linux kernel source code and NVidia packages and
-docker-squash.
-
-
-### Solution
-
-The solution is simply build the Docker image manually, so all changes
-get into a single commit.  During this manual procedure, we delete
-files that are no longer useful.  This starts from the base image of
-ubuntu:14.04:
-
-```
-docker run -it --privileged ubuntu:14.04 /bin/bash
-```
-
-followed by all steps enlisted
-[here](https://github.com/wangkuiyi/es-dev-stack/blob/clone-most-recent-commit-of-linux-kernel/corenvidiadrivers/Dockerfile)
-with RUN and the final CMD.  The final step generates
-`/opt/nvidia/nvidia_installers/NVIDIA-Linux-x86_64-352.39/kernel/uvm/nvidia-uvm.ko`,
-the kernel module we need.  Then all other stuff, Linux kernel source
-code and CUDA things can be deleted.  Then we do
-
-```
-exit # exit from the running of /bin/bash in ubuntu:14:04 container
-docker commit <id>
-```
-
-so to make all our work into a single Docker commit.  The `docker
-commit` command will print a new Docker commit id, say <new_cid>,
-which can be tagged:
-
-```
-docker tag cxwangyi/cuda <new_cid>
-```
-
-An alternative solution is to combine all RUN directives in Dockerfile
-into a single one, so that `docker build` creates a single commit with
-all changes.
-
-### Pitfalls
-
-On my VM and AWS EC2 instances, CoreOS mounts `/tmp` to a small
-in-memory filesystem which is too small.  The solution is simply `sudo
-umount /tmp` so that `/tmp` is on the big disk partition which holds
-`/`.
-
-I tried using docker-squash to reduce the image size.  But it is not
-as effective as grouping all changes into a single Docker commit.
-
-I once forgot to use the `--privilege` option and causes some
+To run an application container of GPU-dependent applications, we need
+the `--privilege` option with `docker run`.  Otherwise it might causes
 confusions as I documented
 [here](https://github.com/emergingstack/es-dev-stack/issues/15).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,16 @@ is to build CUDA driver in a virtual machine on my iMac.
 
 My iMac doesn't run CoreOS, so I need to run a virtual machine with
 CoreOS.  A practical and convenient way to this is to use the standard
-Vagrant CoreOS box.  Here is what I do:
+Vagrant CoreOS box.  But this box doesn't have extraordinarily large
+disk space.  So I save CUDA toolkit and Linux kernel source code on
+host disk and map host directory to the VM.
+
+Other approaches for saving disk space include:
+
+1. checking out only the most recent git commit of Linux kernel source
+   code, and
+1. avoding building a Docker image for building the CUDA driver as
+   https://github.com/emergingstack/es-dev-stack does.
 
 1. Run `git clone` to grab this repo to the host computer.
 1. Run `run.sh`, which

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,143 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
+require 'fileutils'
+
+Vagrant.require_version ">= 1.6.0"
+
+CLOUD_CONFIG_PATH = File.join(File.dirname(__FILE__), "user-data")
+CONFIG = File.join(File.dirname(__FILE__), "config.rb")
+
+# Defaults for config options defined in CONFIG
+$num_instances = 1
+$instance_name_prefix = "core"
+$update_channel = "alpha"
+$image_version = "current"
+$enable_serial_logging = false
+$share_home = false
+$vm_gui = false
+$vm_memory = 4096
+$vm_cpus = 1
+$shared_folders = {}
+$forwarded_ports = {}
+
+# Attempt to apply the deprecated environment variable NUM_INSTANCES to
+# $num_instances while allowing config.rb to override it
+if ENV["NUM_INSTANCES"].to_i > 0 && ENV["NUM_INSTANCES"]
+  $num_instances = ENV["NUM_INSTANCES"].to_i
+end
+
+if File.exist?(CONFIG)
+  require CONFIG
+end
+
+# Use old vb_xxx config variables when set
+def vm_gui
+  $vb_gui.nil? ? $vm_gui : $vb_gui
+end
+
+def vm_memory
+  $vb_memory.nil? ? $vm_memory : $vb_memory
+end
+
+def vm_cpus
+  $vb_cpus.nil? ? $vm_cpus : $vb_cpus
+end
+
+Vagrant.configure("2") do |config|
+  # always use Vagrants insecure key
+  config.ssh.insert_key = false
+
+  config.vm.box = "coreos-%s" % $update_channel
+  if $image_version != "current"
+      config.vm.box_version = $image_version
+  end
+  config.vm.box_url = "https://storage.googleapis.com/%s.release.core-os.net/amd64-usr/%s/coreos_production_vagrant.json" % [$update_channel, $image_version]
+
+  ["vmware_fusion", "vmware_workstation"].each do |vmware|
+    config.vm.provider vmware do |v, override|
+      override.vm.box_url = "https://storage.googleapis.com/%s.release.core-os.net/amd64-usr/%s/coreos_production_vagrant_vmware_fusion.json" % [$update_channel, $image_version]
+    end
+  end
+
+  config.vm.provider :virtualbox do |v|
+    # On VirtualBox, we don't have guest additions or a functional vboxsf
+    # in CoreOS, so tell Vagrant that so it can be smarter.
+    v.check_guest_additions = false
+    v.functional_vboxsf     = false
+  end
+
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
+  (1..$num_instances).each do |i|
+    config.vm.define vm_name = "%s-%02d" % [$instance_name_prefix, i] do |config|
+      config.vm.hostname = vm_name
+
+      if $enable_serial_logging
+        logdir = File.join(File.dirname(__FILE__), "log")
+        FileUtils.mkdir_p(logdir)
+
+        serialFile = File.join(logdir, "%s-serial.txt" % vm_name)
+        FileUtils.touch(serialFile)
+
+        ["vmware_fusion", "vmware_workstation"].each do |vmware|
+          config.vm.provider vmware do |v, override|
+            v.vmx["serial0.present"] = "TRUE"
+            v.vmx["serial0.fileType"] = "file"
+            v.vmx["serial0.fileName"] = serialFile
+            v.vmx["serial0.tryNoRxLoss"] = "FALSE"
+          end
+        end
+
+        config.vm.provider :virtualbox do |vb, override|
+          vb.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
+          vb.customize ["modifyvm", :id, "--uartmode1", serialFile]
+        end
+      end
+
+      if $expose_docker_tcp
+        config.vm.network "forwarded_port", guest: 2375, host: ($expose_docker_tcp + i - 1), auto_correct: true
+      end
+
+      $forwarded_ports.each do |guest, host|
+        config.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
+      end
+
+      ["vmware_fusion", "vmware_workstation"].each do |vmware|
+        config.vm.provider vmware do |v|
+          v.gui = vm_gui
+          v.vmx['memsize'] = vm_memory
+          v.vmx['numvcpus'] = vm_cpus
+        end
+      end
+
+      config.vm.provider :virtualbox do |vb|
+        vb.gui = vm_gui
+        vb.memory = vm_memory
+        vb.cpus = vm_cpus
+      end
+
+      ip = "172.17.8.#{i+100}"
+      config.vm.network :private_network, ip: ip
+
+      # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.
+      config.vm.synced_folder ".", "/home/core/share", nfs: true, mount_options: ['nolock,vers=3,udp']
+      $shared_folders.each_with_index do |(host_folder, guest_folder), index|
+        config.vm.synced_folder host_folder.to_s, guest_folder.to_s, id: "core-share%02d" % index, nfs: true, mount_options: ['nolock,vers=3,udp']
+      end
+
+      if $share_home
+        config.vm.synced_folder ENV['HOME'], ENV['HOME'], id: "home", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+      end
+
+      if File.exist?(CLOUD_CONFIG_PATH)
+        config.vm.provision :file, :source => "#{CLOUD_CONFIG_PATH}", :destination => "/tmp/vagrantfile-user-data"
+        config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
+      end
+
+    end
+  end
+end

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,6 @@
 #/bin/bash
 
 echo Hello!  We are building CUDA driver for your Linux kernel ...
-ls -l /opt/share
 
 # install basic tools
 apt-get -y update

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#/bin/bash
+
+echo Hello!  We are building CUDA driver for your Linux kernel ...
+ls -l /opt/share
+
+# install basic tools
+apt-get -y update
+apt-get -y install wget git bc make dpkg-dev libssl-dev software-properties-common
+
+# install GCC 4.9
+add-apt-repository ppa:ubuntu-toolchain-r/test
+apt-get update
+apt-get install -y gcc-4.9 g++-4.9
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
+
+# clean apt cache
+apt-get clean
+
+# clone Linux kernel source code and prepare for kernel module building.
+cd /opt/share
+git clone -b v`uname -r | sed -e "s/-.*//" | sed -e "s/\.[0]*$//"` --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux
+(
+    cd linux
+    git checkout -b stable
+    zcat /proc/config.gz > .config
+    make modules_prepare
+    sed -i -e "s/`uname -r | sed -e "s/-.*//" | sed -e "s/\.[0]*$//"`/`uname -r`/" include/generated/utsrelease.h # In case a '+' was added
+)
+
+# patch the unpacked
+patch /opt/share/cuda/NVIDIA-Linux-x86_64-352.39/kernel/nv-procfs.c < /opt/share/nvprocfs.patch
+
+# build CUDA kernel module
+/opt/share/cuda/NVIDIA-Linux-x86_64-352.39/nvidia-installer -q -a -n -s --kernel-source-path=/opt/share/linux/
+cp /opt/share/cuda/NVIDIA-Linux-x86_64-352.39/kernel/uvm/nvidia-uvm.ko /opt/share/cuda/
+cp /opt/share/cuda/NVIDIA-Linux-x86_64-352.39/kernel/nvidia.ko /opt/share/cuda/

--- a/nvprocfs.patch
+++ b/nvprocfs.patch
@@ -1,0 +1,15 @@
+360,361c360,363
+< 
+<     return seq_printf(s, "Binary: \"%s\"\n", registry_keys);
+---
+>     //mikes fix below
+>     seq_printf(s, "Binary: \"%s\"\n", registry_keys);
+>     return 0;
+>     //return seq_printf(s, "Binary: \"%s\"\n", registry_keys);
+562c564,567
+<     return seq_puts(s, s->private);
+---
+>     //mikes fix below
+>     seq_puts(s, s->private);
+>     return 0;
+>     //return seq_puts(s, s->private);

--- a/run.sh
+++ b/run.sh
@@ -10,9 +10,9 @@ if [[ ! -d coreos-vagrant ]]; then
 fi
 cp coreos-vagrant/Vagrantfile .
 
-mkdir work
+mkdir cuda
 (
-    cd work
+    cd cuda
     if [[ ! -d NVIDIA-Linux-x86_64-352.39 ]]; then
 	if [[ ! -f NVIDIA-Linux-x86_64-352.39.run ]]; then
 	    if [[ ! -f cuda_7.5.18_linux.run ]]; then

--- a/run.sh
+++ b/run.sh
@@ -24,7 +24,8 @@ mkdir cuda
 )
 
 
-# # Start the virtual cluster. 
+# # Start the virtual cluster.
+vagrant box update
 vagrant up
-vagrant ssh
+vagrant ssh -c "docker build -t cuda /home/core/share && docker run -v /home/core/share:/opt/share cuda"
 

--- a/run.sh
+++ b/run.sh
@@ -23,9 +23,10 @@ mkdir cuda
     fi
 )
 
+rm -rf linux
 
 # # Start the virtual cluster.
 vagrant box update
 vagrant up
-vagrant ssh -c "docker build -t cuda /home/core/share && docker run -v /home/core/share:/opt/share cuda"
+vagrant ssh -c "docker run --rm -v /home/core/share:/opt/share --privileged ubuntu:14.04 /bin/bash /opt/share/build.sh"
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,35 @@
+# This trial is based on https://github.com/emergingstack/es-dev-stack.
+
+if [[ ! -f ./`basename $0` ]]; then
+    echo "Please run this program in the directory where it resides."
+    exit
+fi
+
+if [[ ! -d coreos-vagrant ]]; then
+    git clone -b sync_dir https://github.com/wangkuiyi/coreos-vagrant
+fi
+cp coreos-vagrant/Vagrantfile .
+
+mkdir work
+(
+    cd work
+    if [[ ! -d NVIDIA-Linux-x86_64-352.39 ]]; then
+	if [[ ! -f NVIDIA-Linux-x86_64-352.39.run ]]; then
+	    if [[ ! -f cuda_7.5.18_linux.run ]]; then
+		wget http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda_7.5.18_linux.run
+	    fi
+
+	    chmod +x cuda_7.5.18_linux.run
+	    ./cuda_7.5.18_linux.run -extract=`pwd`
+	fi
+
+	chmod +x ./NVIDIA-Linux-x86_64-352.39.run
+	./NVIDIA-Linux-x86_64-352.39.run -a -x --ui=none
+    fi
+)
+
+
+# # Start the virtual cluster. 
+# vagrant up
+# vagrant ssh
+

--- a/run.sh
+++ b/run.sh
@@ -5,11 +5,6 @@ if [[ ! -f ./`basename $0` ]]; then
     exit
 fi
 
-if [[ ! -d coreos-vagrant ]]; then
-    git clone -b sync_dir https://github.com/wangkuiyi/coreos-vagrant
-fi
-cp coreos-vagrant/Vagrantfile .
-
 mkdir cuda
 (
     cd cuda
@@ -30,6 +25,6 @@ mkdir cuda
 
 
 # # Start the virtual cluster. 
-# vagrant up
-# vagrant ssh
+vagrant up
+vagrant ssh
 


### PR DESCRIPTION
和我之前手工安装CoreOS VM然后在VM里手工操作不同，这次用Vagrant来创建CoreOS VM，并且自动在VM build Docker image，并且运行这个image来build CUDA driver。

因为我把host机器的目录通过NFS共享给VM，并且map给Docker container了，所以当Docker container在工作期间，大文件（CUDA Toolkit installer和Linux kernel source code）都下载到host目录里。这就解决了曾经很挠头的磁盘空间不够的问题。
